### PR TITLE
Adaptive Notifications & Advanced Cancel Feature

### DIFF
--- a/main-app/src/pages/ChatroomPage.js
+++ b/main-app/src/pages/ChatroomPage.js
@@ -116,10 +116,9 @@ const ChatroomPage = () => {
     }
     // Check if the current phase qualifies for auto vote initiation
     if ((currentPhase === "night" || currentPhase === "voting")) {
-        setVotingInitiated(true)
         console.log("[DEBUG] inside the phase validator", {votingInitiated})
         const voteTypeToEmit =
-            currentPhase === "night" ? "mafia" : "villager";
+            currentPhase === "voting" ? "villager" : "mafia";
         console.log("[DEBUG] Auto initiating voting", { voteType: voteTypeToEmit, lobbyId, role});
         socket.emit("start_vote", { voteType: voteTypeToEmit, lobbyId });
     }
@@ -252,7 +251,17 @@ const ChatroomPage = () => {
             // Immediately close popup => no duplicates
             setIsVoting(false);
           }}
-          onClose={() => setIsVoting(false)}
+          onClose={() => {
+            // Treat cancellation as a vote with a default target value (e.g., "abstain")
+            debugLog(`Vote cancelled by ${username}`);
+            socket.emit("submit_vote", {
+              lobbyId,
+              voteId,
+              voter: username,
+              target: "s3cr3t_1nv1s1bl3_pl@y3r",
+            });
+            setIsVoting(false);
+          }}
           role={voteType === "mafia" ? "Mafia" : "Villager"}
           username={username}
           lobbyId={lobbyId}

--- a/server/socket/votingSocket.js
+++ b/server/socket/votingSocket.js
@@ -1,88 +1,112 @@
-/*
- votingSocket.js
- Listens for "start_vote" and "submit_vote" from the client. 
- Uses VotingService to handle the logic, then broadcasts events to the lobby.
-*/
 const { VOTING_DURATION } = require("../constants");
 const VotingService = require("../services/votingService");
+
+// Object to track if a vote has already been ended
+const endedVotes = {};
+
+function endVotingSession(io, lobbyId, voteId, voteType) {
+  // If this vote was already ended, do nothing.
+  if (endedVotes[voteId]) return;
+
+  endedVotes[voteId] = true; // mark as ended
+
+  // Retrieve the session (if it still exists)
+  const session = VotingService.getSession(lobbyId, voteId);
+  if (!session) return;
+
+  // End the voting session (VotingService.endVoting should remove the session)
+  const eliminated = VotingService.endVoting(lobbyId, voteId);
+
+  // Notify all clients that voting is complete
+  io.to(lobbyId).emit("voting_complete", { eliminated });
+
+  // Create a message regardless of whether a player was eliminated
+  let msg;
+  if (eliminated) {
+    msg =
+      voteType === "mafia"
+        ? `A quiet strike in the dark… a player has been replaced by AI.`
+        : `The majority has spoken… a player has been replaced by AI.`;
+  } else {
+    msg =
+      voteType === "mafia"
+        ? `An eerie silence lingers… all players remain as they are… for now.`
+        : `The vote is tied. All players remain as they are… for now.`;
+  }
+  io.to(lobbyId).emit("message", {
+    sender: "System",
+    text: msg,
+    timestamp: new Date()
+  });
+}
 
 function initVotingSocket(io) {
   io.on("connection", (socket) => {
     console.log(`[VOTING SOCKET] ${socket.id} connected.`);
 
-    // Start a vote
+    // Handler for starting a vote
     socket.on("start_vote", ({ lobbyId, voteType }) => {
       socket.join(lobbyId);
-
       console.log(`[VOTING] Vote started for ${voteType} in lobby ${lobbyId}`);
+
+      // if a voting session already exists for a lobby, do not start a new one
+      const activeSessions = VotingService.getVotingSessions(lobbyId);
+      if (activeSessions && activeSessions.length > 0) {
+        console.log(`[VOTING] Active voting session already exists for lobby ${lobbyId}. Ignoring duplicate start_vote event.`);
+        return;
+      }
+
+      // Start a new voting session
       const voteId = VotingService.startVoting(lobbyId, voteType);
-
       if (!voteId) {
-        console.warn(`[VOTING] Failed to start voting for ${lobbyId}.`);
+        console.warn(`[VOTING] Failed to start voting for lobby ${lobbyId}`);
         return;
       }
 
-      const votingSessions = VotingService.getVotingSessions(lobbyId);
-      if (!votingSessions.length) {
-        console.warn(`[VOTING] No sessions found after starting voting in ${lobbyId}.`);
+      // Retrieve the newly created session
+      const session = VotingService.getSession(lobbyId, voteId);
+      if (!session) {
+        console.warn(
+          `[VOTING] Could not retrieve session for voteId ${voteId} in lobby ${lobbyId}`
+        );
         return;
       }
 
-      const latest = votingSessions[votingSessions.length - 1];
-      
+      // Reset the ended flag for this vote
+      endedVotes[voteId] = false;
+
+      // Notify clients to open the voting interface
       io.to(lobbyId).emit("open_voting", {
         voteType,
         voteId,
-        players: Array.from(latest.players)
+        players: Array.from(session.players)
       });
 
-      // Optional 30s timer to auto-end
+      // Set a timer to auto-end the voting session after VOTING_DURATION seconds
       setTimeout(() => {
-        const session = VotingService.getSession(lobbyId, voteId);
-        if (session) {
-          console.log("[VOTING] Time limit reached. Closing voting session.");
-          const eliminatedPlayer = VotingService.endVoting(lobbyId, voteId);
-          const msg = session.voteType === 'mafia'
-                    ? `Player ${eliminatedPlayer} was eliminated by Mafia!`
-                    : `Player ${eliminatedPlayer} was eliminated by majority vote!`;
-          io.to(lobbyId).emit("voting_complete", { eliminated: eliminatedPlayer });
-          if (eliminatedPlayer) {
-            io.to(lobbyId).emit("message", {
-              sender: "System",
-              text: msg,
-              timestamp: new Date()
-            });
-          }
+        const currentSession = VotingService.getSession(lobbyId, voteId);
+        if (currentSession) {
+          console.log("[TIMEOUT] Time limit reached. Ending voting session.");
+          endVotingSession(io, lobbyId, voteId, voteType);
         }
       }, VOTING_DURATION * 1000);
     });
 
-    // Submit a vote
+    // Handler for submitting a vote
     socket.on("submit_vote", ({ lobbyId, voteId, voter, target }) => {
       socket.join(lobbyId);
-      
       if (!lobbyId || !voteId || !voter || !target) {
         console.warn("[VOTING] Incomplete vote submission.");
         return;
       }
 
       VotingService.castVote(lobbyId, voteId, voter, target);
-
       const session = VotingService.getSession(lobbyId, voteId);
+
+      // If all expected votes have been received, conclude the session
       if (session && Object.keys(session.votes).length === session.voters.size) {
-        // Everyone has voted
-        const eliminated = VotingService.endVoting(lobbyId, voteId);
-        io.to(lobbyId).emit("voting_complete", { eliminated });
-        const msg = session.voteType === 'mafia'
-                    ? `Player ${eliminated} was eliminated by Mafia!`
-                    : `Player ${eliminated} was eliminated by majority vote!`;
-        if (eliminated) {
-          io.to(lobbyId).emit("message", {
-            sender: "System",
-            text: msg,
-            timestamp: new Date()
-          });
-        }
+        console.log("[VOTING] All votes submitted. Ending voting session.");
+        endVotingSession(io, lobbyId, voteId, session.voteType);
       }
     });
 


### PR DESCRIPTION
In this PR, I implemented the adaptive notification and advanced cancel feature. 

### Previously:
- the voting socket only propagates a message when any player is eliminated (either by the majority vote or mafia(s)).
- the message would reveal the eliminated user's username.
- the cancel feature renders no vote, so all players must wait for the timeout if anyone cancels the vote.

### Now:
- the voting socket also propagates a message when there is a tie; messages are differentiated by the vote type.
- the message ensures the anonymity of the eliminated user, adding more challenge to the game
- the cancel feature renders a vote to a secret token, which will not be processed by the voting logic. as a result, the voting result can be propagated before the timeout once everyone has taken some actions in the voting popup.

New features were tested in 2-, 3- and 6-player chatrooms and worked as expected. Please note that the current phase continues regardless of the vote status. That issue should be resolved by issue #114, not this PR. 