### PR TITLE
Visual Cues for Eliminated Players & Other UI Enhancement

### DIFF
--- a/main-app/src/pages/ChatroomPage.js
+++ b/main-app/src/pages/ChatroomPage.js
@@ -29,6 +29,7 @@ const ChatroomPage = () => {
   const [voteId, setVoteId] = useState(null);
   const [players, setPlayers] = useState([]);
   const [isVoteLocked, setIsVoteLocked] = useState(false);
+  const [showEliminationMessage, setShowEliminationMessage] = useState(false);
 
   const debugLog = (msg, data = null) => console.log(`[DEBUG] ${msg}`, data);
 
@@ -152,11 +153,18 @@ const ChatroomPage = () => {
     };
 
     const handleVotingComplete = ({ eliminated }) => {
-      debugLog("voting_complete", { eliminated });
+      debugLog("voting_complete", { eliminated, username});
       setIsVoting(false);
       setIsVoteLocked(false);
-      if (eliminated === username) {
-        setIsEliminated(true);
+      if (eliminated){
+        if (eliminated.trim().toLowerCase() === username.trim().toLowerCase()) {
+          setIsEliminated(true);
+          console.log("[DEBUG] Set IsEliminated to True")
+          setShowEliminationMessage(true);
+          setTimeout(() => {
+            setShowEliminationMessage(false);
+          }, 6000);
+        }
       }
     };
 
@@ -188,10 +196,10 @@ const ChatroomPage = () => {
   };
 
   return (
-    <div className={`chatroom-container ${currentPhase === "night" ? "night-mode" : ""}`}>
+    <div className={`chatroom-container ${currentPhase === "night" ? "night-mode" : ""} ${isEliminated ? "eliminated" : ""}`}>
       <div className="chatroom-header">
         <h2>{currentPhase === "voting" ? "DAY" : currentPhase.toUpperCase()}</h2>
-        <button className="back-button" onClick={() => navigate("/")}>Back to Home</button>
+        {/* <button className="back-button" onClick={() => navigate("/")}>Back to Home</button> */}
 
         <div className="phase-timer">{formatTime(timeLeft)}</div>
       </div>
@@ -213,10 +221,10 @@ const ChatroomPage = () => {
       </div>
 
       {!(currentPhase === "voting" || currentPhase === "night") && (
-        <div className="chatroom-input-container">
+        <div className={`chatroom-input-container ${isEliminated ? "disabled" : ""}`}>
           <textarea
             className="chatroom-input"
-            rows="2"
+            rows="4"
             placeholder="Type your message..."
             value={message}
             onChange={(e) => setMessage(e.target.value)}
@@ -267,7 +275,10 @@ const ChatroomPage = () => {
           lobbyId={lobbyId}
         />
       )}
-    </div>
+      {showEliminationMessage && (
+          <div className="elimination-message">Your presence fades into the unknown… AI takes your place.</div>
+      )}
+      </div>
   );
 };
 

--- a/main-app/src/styles/ChatroomPage.css
+++ b/main-app/src/styles/ChatroomPage.css
@@ -111,6 +111,9 @@
   font-size: 1rem;
   font-family: serif;
   color: #110101;
+  resize: none;
+  overflow-y: auto;
+  max-height: 100px;
 }
 
 /* Send button */
@@ -256,6 +259,41 @@
 
 .night-mode .voting-controls button.mafia-player:hover {
   background-color: #5f0903;
+}
+
+/* Fade in/out animation for the elimination message */
+.elimination-message {
+  position: fixed;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  font-family: 'gothic';
+  font-size: 2rem;
+  color: red;
+  z-index: 1000;
+  opacity: 0;
+  white-space: nowrap;
+  text-align: center;
+  animation: fadeInOut 6s forwards;
+}
+
+@keyframes fadeInOut {
+  0% { opacity: 0; }
+  20% { opacity: 1; }
+  80% { opacity: 1; }
+  100% { opacity: 0; }
+}
+
+/* Dim the entire chatroom when eliminated */
+.chatroom-container.eliminated {
+  filter: brightness(0.43) !important;
+}
+
+/* Disable pointer events for the input area when eliminated */
+.chatroom-input-container.disabled {
+  pointer-events: none;
+  cursor: default;
+  opacity: 0.5;
 }
 
 /* .night-mode .role-banner {


### PR DESCRIPTION
In this PR, I introduce **visual cues for eliminated players**, update the **chat input box behavior**, and **remove the back-to-home button**.  

## Changes Made  

### 1. **Elimination UI Enhancements**  
- Added an **elimination pop-up message** when a player is removed.  
- Updated the chatroom to:  
  - Display a message once a player is eliminated.
  - Dim the UI for eliminated players.  
  - Disable chat input after elimination.  (Previously, they could enter but could not send.)

### 2. **Chat Input Box Fixes**  
- Prevented manual resizing.
- Enabled auto-scrolling when text overflows.  

### 3. **Removed Back-to-Home Button**  
- Removed the **back-to-home button** from the chatroom per inter-team feedback.  

## Screenshots

### 1. Regular UI
<img width="1413" alt="regular_UI" src="https://github.com/user-attachments/assets/02c4df67-3108-471b-8856-ecbfc4bee30e" />

### 2. UI right after being eliminated
<img width="1410" alt="right_after" src="https://github.com/user-attachments/assets/8783fc71-5100-4514-b973-b2ff471961ac" />

### 3. Eliminated UI
<img width="1416" alt="eliminated_UI" src="https://github.com/user-attachments/assets/3a417581-5a63-4508-b406-9a949c459f43" />

Closes #120 



